### PR TITLE
Update Kiwi provider to v2 RapidAPI endpoint

### DIFF
--- a/agent/providers/kiwi.py
+++ b/agent/providers/kiwi.py
@@ -7,11 +7,11 @@ def get_kiwi_deals(params):
     if not key:
         raise RuntimeError("RAPIDAPI_KIWI_KEY environment variable is not set")
 
-    url = "https://kiwi-com-cheap-flights.p.rapidapi.com/search"
+    url = "https://kiwi-com.p.rapidapi.com/v2/search"
 
     headers = {
         "X-RapidAPI-Key": key,
-        "X-RapidAPI-Host": "kiwi-com-cheap-flights.p.rapidapi.com",
+        "X-RapidAPI-Host": "kiwi-com.p.rapidapi.com",
     }
 
     formatted_date = datetime.strptime(params["startDate"], "%Y-%m-%d").strftime("%d/%m/%Y")

--- a/agent/tests/test_kiwi.py
+++ b/agent/tests/test_kiwi.py
@@ -37,6 +37,13 @@ def test_get_kiwi_deals_success():
       deals = get_kiwi_deals(sample_params())
   assert deals[0]["price"] == 100
   mock_get.assert_called_once()
+  called_url = mock_get.call_args[0][0]
+  called_headers = mock_get.call_args[1]["headers"]
+  called_params = mock_get.call_args[1]["params"]
+  assert called_url == "https://kiwi-com.p.rapidapi.com/v2/search"
+  assert called_headers["X-RapidAPI-Host"] == "kiwi-com.p.rapidapi.com"
+  assert called_params["date_from"] == "01/09/2024"
+  assert called_params["date_to"] == "01/09/2024"
 
 
 def test_get_kiwi_deals_error():


### PR DESCRIPTION
## Summary
- use `https://kiwi-com.p.rapidapi.com/v2/search` with updated `X-RapidAPI-Host`
- verify query parameters and format for Kiwi v2 API
- expand unit test to assert correct URL, host header and date formatting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897a65799fc83328fea4b8293b63bc2