### PR TITLE
Gracefully handle provider HTTP errors

### DIFF
--- a/agent/providers/amadeus.py
+++ b/agent/providers/amadeus.py
@@ -1,6 +1,9 @@
 import os
+import logging
 import requests
 from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
 
 def get_amadeus_access_token():
     client_id = os.getenv("AMADEUS_API_KEY")
@@ -51,8 +54,8 @@ def get_amadeus_hotels(params):
     try:
         res = requests.get(url, headers=headers, params=query)
         res.raise_for_status()
-    except Exception as e:
-        print(f"[Amadeus] API call failed: {e}")
+    except Exception:
+        logger.exception("[Amadeus] API call failed")
         return []
 
     raw_data = res.json().get("data", [])

--- a/agent/providers/kiwi.py
+++ b/agent/providers/kiwi.py
@@ -1,6 +1,9 @@
 import os
 from datetime import datetime
+import logging
 import requests
+
+logger = logging.getLogger(__name__)
 
 def get_kiwi_deals(params):
     key = os.getenv("RAPIDAPI_KIWI_KEY")
@@ -34,8 +37,8 @@ def get_kiwi_deals(params):
         response = requests.get(url, headers=headers, params=querystring)
         response.raise_for_status()
         results = response.json().get("data", [])
-    except Exception as e:
-        print(f"[Kiwi] API call failed: {e}")
+    except Exception:
+        logger.exception("[Kiwi] API call failed")
         return []
 
     output = []

--- a/agent/travel_deal_agent.py
+++ b/agent/travel_deal_agent.py
@@ -2,6 +2,7 @@ import os
 import json
 import argparse
 from datetime import datetime
+import requests
 from providers.kiwi import get_kiwi_deals
 from providers.amadeus import get_amadeus_hotels
 
@@ -23,11 +24,19 @@ def save_results(data, output_dir="results"):
 
 def evaluate_deals(params):
     print("[INFO] Fetching flight data via Kiwi...")
-    flights = get_kiwi_deals(params)
+    try:
+        flights = get_kiwi_deals(params)
+    except requests.HTTPError as e:
+        print(f"[ERROR] Kiwi provider HTTP error: {e}")
+        flights = []
     print(f"[INFO] Found {len(flights)} flight options.")
 
     print("[INFO] Fetching hotel data via Amadeus...")
-    hotels = get_amadeus_hotels(params)
+    try:
+        hotels = get_amadeus_hotels(params)
+    except requests.HTTPError as e:
+        print(f"[ERROR] Amadeus provider HTTP error: {e}")
+        hotels = []
     print(f"[INFO] Found {len(hotels)} hotel options.")
 
     results = []


### PR DESCRIPTION
## Summary
- Add logging-based exception handling for Kiwi and Amadeus provider requests, returning empty lists on failure
- Guard TravelDealAgent provider calls against HTTPError so failed providers yield no results

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897a66ac67083329b4ac4c01908e615