### PR TITLE
Update Kiwi provider RapidAPI host

### DIFF
--- a/agent/providers/kiwi.py
+++ b/agent/providers/kiwi.py
@@ -10,11 +10,11 @@ def get_kiwi_deals(params):
     if not key:
         raise RuntimeError("RAPIDAPI_KIWI_KEY environment variable is not set")
 
-    url = "https://kiwi-com.p.rapidapi.com/v2/search"
+    url = "https://kiwi-com-cheap-flights.p.rapidapi.com/v2/search"
 
     headers = {
         "X-RapidAPI-Key": key,
-        "X-RapidAPI-Host": "kiwi-com.p.rapidapi.com",
+        "X-RapidAPI-Host": "kiwi-com-cheap-flights.p.rapidapi.com",
     }
 
     formatted_date = datetime.strptime(params["startDate"], "%Y-%m-%d").strftime("%d/%m/%Y")

--- a/agent/tests/test_kiwi.py
+++ b/agent/tests/test_kiwi.py
@@ -40,8 +40,8 @@ def test_get_kiwi_deals_success():
   called_url = mock_get.call_args[0][0]
   called_headers = mock_get.call_args[1]["headers"]
   called_params = mock_get.call_args[1]["params"]
-  assert called_url == "https://kiwi-com.p.rapidapi.com/v2/search"
-  assert called_headers["X-RapidAPI-Host"] == "kiwi-com.p.rapidapi.com"
+  assert called_url == "https://kiwi-com-cheap-flights.p.rapidapi.com/v2/search"
+  assert called_headers["X-RapidAPI-Host"] == "kiwi-com-cheap-flights.p.rapidapi.com"
   assert called_params["date_from"] == "01/09/2024"
   assert called_params["date_to"] == "01/09/2024"
 


### PR DESCRIPTION
## Summary
- switch Kiwi API calls to `kiwi-com-cheap-flights.p.rapidapi.com`
- adjust tests for new RapidAPI host and endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897c21489c083329a47f97eca1f9469